### PR TITLE
removed closing php tags from non-view files

### DIFF
--- a/conf_default.php
+++ b/conf_default.php
@@ -65,5 +65,3 @@ $conf['graph_all_periods_timeframes'] = array(
     "6+months",
     "12+months"
 );
-
-?>

--- a/functions.php
+++ b/functions.php
@@ -261,5 +261,3 @@ function find_metrics($search_string, $group_depth=0) {
     curl_close($ch);
     return $metrics;
 }
-
-?>

--- a/graph_all_periods.php
+++ b/graph_all_periods.php
@@ -36,4 +36,3 @@ foreach ($conf["graph_all_periods_timeframes"] as $tf) {
 
 print "</div>";
 include_once "./footer.php";
-?>

--- a/include_conf.php
+++ b/include_conf.php
@@ -7,4 +7,3 @@ require_once $base_dir . "/conf_default.php";
 if( file_exists( $base_dir . "/conf.php" ) ) {
     include_once $base_dir . "/conf.php";
 }
-?>

--- a/index.php
+++ b/index.php
@@ -33,5 +33,3 @@ if ($view)
 
 print "</div>";
 include_once "./footer.php";
-?>
-


### PR DESCRIPTION
avoid generating output that can destroy for example image data.
Closing PHP tags are not necessary and it is good practice to avoid them in files that contain only PHP code.
For the graph.php this is already done in #1 
